### PR TITLE
Revise summary met data generation

### DIFF
--- a/app/Exports/Download/Met/MonthlyMetDataExport.php
+++ b/app/Exports/Download/Met/MonthlyMetDataExport.php
@@ -75,6 +75,7 @@ class MonthlyMetDataExport implements FromQuery, WithTitle, WithHeadings, WithSt
             $monthlyMetData->max_humedad_interna,
             $monthlyMetData->min_humedad_interna,
             $monthlyMetData->avg_humedad_interna,
+            $monthlyMetData->max_temperatura_externa,
             $monthlyMetData->min_temperatura_externa,
             $monthlyMetData->avg_temperatura_externa,
             $monthlyMetData->max_humedad_externa,

--- a/app/Exports/Download/Met/TendaysMetDataExport.php
+++ b/app/Exports/Download/Met/TendaysMetDataExport.php
@@ -80,6 +80,7 @@ class TendaysMetDataExport implements FromQuery, WithTitle, WithHeadings, WithSt
             $tendaysMetData->max_humedad_interna,
             $tendaysMetData->min_humedad_interna,
             $tendaysMetData->avg_humedad_interna,
+            $tendaysMetData->max_temperatura_externa,
             $tendaysMetData->min_temperatura_externa,
             $tendaysMetData->avg_temperatura_externa,
             $tendaysMetData->max_humedad_externa,

--- a/app/Exports/Download/Met/YearlyMetDataExport.php
+++ b/app/Exports/Download/Met/YearlyMetDataExport.php
@@ -75,6 +75,7 @@ class YearlyMetDataExport implements FromQuery, WithTitle, WithHeadings, WithStr
             $yearlyMetData->max_humedad_interna,
             $yearlyMetData->min_humedad_interna,
             $yearlyMetData->avg_humedad_interna,
+            $yearlyMetData->max_temperatura_externa,
             $yearlyMetData->min_temperatura_externa,
             $yearlyMetData->avg_temperatura_externa,
             $yearlyMetData->max_humedad_externa,

--- a/database/migrations/2022_06_27_131930_revise_generate_daily_met_data.php
+++ b/database/migrations/2022_06_27_131930_revise_generate_daily_met_data.php
@@ -1,0 +1,118 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateDailyMetData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_daily_met_data`;
+
+CREATE PROCEDURE `generate_daily_met_data`(IN id_date VARCHAR(10), IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating daily_met_data record for a specific date and a specific station
+*/
+
+	DECLARE expected_number_of_records INT;
+	DECLARE actual_number_of_records INT;
+	
+	-- assume met station performs measurement every 15 minutes
+	-- number of records per day = 4 * 24 = 96
+	SET expected_number_of_records = 96;
+	
+	-- delete daily_met_data record for a specfic date and a specific station
+	DELETE FROM daily_met_data
+	WHERE fecha = id_date
+	AND station_id = iv_station_id;
+	
+	-- find number of raw met data records
+	SELECT COUNT(*)
+	INTO actual_number_of_records
+	FROM met_data
+	WHERE fecha_hora BETWEEN 
+	id_date AND DATE_ADD(DATE_ADD(id_date, INTERVAL 1 DAY), INTERVAL -1 SECOND)
+	AND station_id = iv_station_id;
+	
+
+	IF (actual_number_of_records = 0) THEN
+	
+		-- generate daily_met_data record with null values because there is no raw met data record
+		INSERT INTO daily_met_data 
+		(fecha, station_id, 
+		actual_no_of_records, expected_no_of_records,
+		created_at, updated_at)
+		VALUES
+		(id_date, iv_station_id,
+		0, expected_number_of_records,
+		NOW(), NOW()
+		);
+	
+	ELSE
+	
+		-- generate daily_met_data record by summarizing all records for a specific date and a specific station
+		INSERT INTO daily_met_data 
+		(fecha, station_id, 
+		max_temperatura_interna, min_temperatura_interna, avg_temperatura_interna,
+		max_humedad_interna, min_humedad_interna, avg_humedad_interna,
+		max_temperatura_externa, min_temperatura_externa, avg_temperatura_externa,
+		max_humedad_externa, min_humedad_externa, avg_humedad_externa,
+		max_presion_relativa, min_presion_relativa, avg_presion_relativa, 
+		max_presion_absoluta, min_presion_absoluta, avg_presion_absoluta, 
+		max_velocidad_viento, min_velocidad_viento, avg_velocidad_viento, 
+		max_sensacion_termica, min_sensacion_termica, avg_sensacion_termica, 
+		lluvia_24_horas_total,
+		actual_no_of_records, expected_no_of_records,
+		created_at, updated_at)
+		SELECT 
+		DATE_FORMAT(fecha_hora, '%Y-%m-%d'), station_id,
+		MAX(temperatura_interna), MIN(temperatura_interna), AVG(temperatura_interna),
+		MAX(humedad_interna), MIN(humedad_interna), AVG(humedad_interna),
+		MAX(temperatura_externa), MIN(temperatura_externa), AVG(temperatura_externa),
+		MAX(humedad_externa), MIN(humedad_externa), AVG(humedad_externa),
+		MAX(presion_relativa), MIN(presion_relativa), AVG(presion_relativa),
+		MAX(presion_absoluta), MIN(presion_absoluta), AVG(presion_absoluta),
+		MAX(velocidad_viento), MIN(velocidad_viento), AVG(velocidad_viento),
+		MAX(sensacion_termica), MIN(sensacion_termica), AVG(sensacion_termica),
+		SUM(lluvia_total), 
+		COUNT(*), expected_number_of_records,
+		NOW(), NOW()
+		FROM met_data
+		WHERE fecha_hora BETWEEN 
+		id_date AND DATE_ADD(DATE_ADD(id_date, INTERVAL 1 DAY), INTERVAL -1 SECOND)
+		AND station_id = iv_station_id
+		GROUP BY DATE_FORMAT(fecha_hora, '%Y-%m-%d'), station_id;
+	
+	END IF;
+	
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_daily_met_data` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_06_27_131930_revise_generate_daily_met_data.php
+++ b/database/migrations/2022_06_27_131930_revise_generate_daily_met_data.php
@@ -38,7 +38,8 @@ BEGIN
 	DELETE FROM daily_met_data
 	WHERE fecha = id_date
 	AND station_id = iv_station_id;
-	
+
+
 	-- find number of raw met data records
 	SELECT COUNT(*)
 	INTO actual_number_of_records
@@ -62,7 +63,7 @@ BEGIN
 		);
 	
 	ELSE
-	
+
 		-- generate daily_met_data record by summarizing all records for a specific date and a specific station
 		INSERT INTO daily_met_data 
 		(fecha, station_id, 
@@ -81,13 +82,13 @@ BEGIN
 		DATE_FORMAT(fecha_hora, '%Y-%m-%d'), station_id,
 		MAX(temperatura_interna), MIN(temperatura_interna), AVG(temperatura_interna),
 		MAX(humedad_interna), MIN(humedad_interna), AVG(humedad_interna),
-		MAX(temperatura_externa), MIN(temperatura_externa), AVG(temperatura_externa),
+		MAX(hi_temp), MIN(low_temp), AVG(temperatura_externa),
 		MAX(humedad_externa), MIN(humedad_externa), AVG(humedad_externa),
 		MAX(presion_relativa), MIN(presion_relativa), AVG(presion_relativa),
 		MAX(presion_absoluta), MIN(presion_absoluta), AVG(presion_absoluta),
-		MAX(velocidad_viento), MIN(velocidad_viento), AVG(velocidad_viento),
+		MAX(hi_speed), MIN(velocidad_viento), AVG(velocidad_viento),
 		MAX(sensacion_termica), MIN(sensacion_termica), AVG(sensacion_termica),
-		SUM(lluvia_total), 
+		SUM(rain), 
 		COUNT(*), expected_number_of_records,
 		NOW(), NOW()
 		FROM met_data
@@ -95,7 +96,7 @@ BEGIN
 		id_date AND DATE_ADD(DATE_ADD(id_date, INTERVAL 1 DAY), INTERVAL -1 SECOND)
 		AND station_id = iv_station_id
 		GROUP BY DATE_FORMAT(fecha_hora, '%Y-%m-%d'), station_id;
-	
+
 	END IF;
 	
 END


### PR DESCRIPTION
There are 2 modifications:
1. Revise summary met data generation
2. Bug fix for data extraction for 1 column shifted (to add missing column max_temperatura_externa)

According to our meeting with UMSA on 2022-06-24 (Fri), Marco mentioned that it would be good if empty record is also generated for a date without any raw met data.

I think it is a good suggestion because:
1. This can show data existence clearly
2. This can show complete calendar days
3. This help to generate graph easily with all calendar days in extracted file

I have modified the stored procedure for generating daily met data only. It is not necessary to modify stored procedure for generating tendays, monthly, yearly. Because when we have daily met data records, tendays, monthly and yearly summary records will be generated.

I recall that generating all summary met data records takes around 2 minutes in local env last time. But now it takes around 13 minutes to do so. Finetuning may be required.
