### PR TITLE
Revise stored procedures for generating summary met data, to accept station id as parameter

### DIFF
--- a/database/migrations/2022_07_06_121039_revise_generate_all_summary_met_data.php
+++ b/database/migrations/2022_07_06_121039_revise_generate_all_summary_met_data.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateAllSummaryMetData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_all_summary_met_data`;
+
+CREATE PROCEDURE `generate_all_summary_met_data`()
+BEGIN
+
+/*
+	Stored procedure for generating all summary met data (daily, tendays, monthly, yearly) from all raw met data
+*/
+
+	-- remove all existing summary met data records
+	DELETE FROM daily_met_data;
+	
+	DELETE FROM tendays_met_data;
+	
+	DELETE FROM monthly_met_data;
+	
+	DELETE FROM yearly_met_data;
+
+
+	-- find minimum and maximum date, year, month from raw met data
+	SELECT
+		DATE(MIN(fecha_hora)), YEAR(MIN(fecha_hora)), MONTH(MIN(fecha_hora)),
+		DATE(MAX(fecha_hora)), YEAR(MAX(fecha_hora)), MONTH(MAX(fecha_hora))
+	INTO
+		@min_date, @min_year, @min_month,
+		@max_date, @max_year, @max_month
+	FROM 
+		met_data;
+		
+
+	-- call stored procedures to generate all summary met data (daily, tendays, monthly, yearly)
+	CALL generate_daily_met_data_by_date_range(@min_date, @max_date, NULL);
+	
+	CALL generate_tendays_met_data_by_year_range(@min_year, @max_year, NULL);
+	
+	CALL generate_monthly_met_data_by_month_range(@min_year, @min_month, @max_year, @max_month, NULL);
+	
+	CALL generate_yearly_met_data_by_year_range(@min_year, @max_year, NULL);
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_all_summary_met_data` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121309_revise_generate_daily_met_data_by_date.php
+++ b/database/migrations/2022_07_06_121309_revise_generate_daily_met_data_by_date.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateDailyMetDataByDate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_daily_met_data_by_date`;
+
+CREATE PROCEDURE `generate_daily_met_data_by_date`(IN id_date VARCHAR(10), IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating daily_met_data record for a specific date for all stations one by one
+*/
+
+	-- variable to determine whether it is end of cursor
+	DECLARE done INT DEFAULT FALSE;
+	
+	-- station ID
+	DECLARE station_id INT;
+	
+	-- cursor to loop through all station IDs
+	DECLARE cur1 CURSOR FOR SELECT id FROM stations ORDER BY id;
+	
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+	
+	IF (iv_station_id IS NULL) THEN
+
+		-- open cursor
+		OPEN cur1;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur1 INTO station_id;
+		    
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate daily_met_data for a specific date for a specific station
+		    CALL generate_daily_met_data(id_date, station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur1;
+	
+	ELSE
+	
+		-- call stored procedure to calculate daily_met_data for a specific date for a specific station
+		CALL generate_daily_met_data(id_date, iv_station_id);
+	
+	END IF;	
+	
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_daily_met_data_by_date` ";
+
+        DB::unprepared($procedure);
+    }
+}
+

--- a/database/migrations/2022_07_06_121314_revise_generate_daily_met_data_by_date_range.php
+++ b/database/migrations/2022_07_06_121314_revise_generate_daily_met_data_by_date_range.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateDailyMetDataByDateRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_daily_met_data_by_date_range`;
+
+CREATE PROCEDURE `generate_daily_met_data_by_date_range`(IN id_from_date VARCHAR(10), IN id_to_date VARCHAR(10), IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating daily_met_data records for a date range for all met stations one by one
+*/
+
+	-- day difference between to_date and from_date
+	DECLARE diff INT;
+	
+	-- loop counter
+	DECLARE counter INT;
+	
+	-- date variable
+	DECLARE d_date DATE;
+	
+	
+	-- calculate date difference between to_date and from_date
+	SELECT DATEDIFF(id_to_date, id_from_date) INTO diff;
+	
+	-- to_date must greater than or equal to from_date
+	-- do nothing if to_date is less than from_date
+	IF (diff >= 0) THEN
+	
+		-- initialize counter
+		SET counter = 0;
+	
+		-- loop every day
+		for_loop: LOOP
+		
+			-- exit loop when all days handled
+			IF (counter > diff) THEN
+				LEAVE for_loop;
+			END IF;
+			
+			-- calculate a date
+			SELECT DATE_ADD(id_from_date, INTERVAL counter DAY) INTO d_date;
+			
+			IF (iv_station_id IS NULL) THEN
+				-- generate daily summary for all stations for a calculated date
+				CALL generate_daily_met_data_by_date(d_date, NULL);
+			ELSE
+				-- generate daily summary for a station for a calculated date
+				CALL generate_daily_met_data_by_date(d_date, iv_station_id);
+			END IF;
+			
+			-- increment counter
+			SET counter = counter + 1;
+		
+		END LOOP for_loop;
+	
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_daily_met_data_by_date_range` ";
+
+        DB::unprepared($procedure);
+    }
+}
+

--- a/database/migrations/2022_07_06_121318_revise_generate_monthly_met_data_by_month.php
+++ b/database/migrations/2022_07_06_121318_revise_generate_monthly_met_data_by_month.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateMonthlyMetDataByMonth extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_monthly_met_data_by_month`;
+
+CREATE PROCEDURE `generate_monthly_met_data_by_month`(IN ii_year INT, IN ii_month INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating monthly_met_data record for a specific month for all stations one by one
+*/
+
+	-- variable to determine whether it is end of cursor
+	DECLARE done INT DEFAULT FALSE;
+	
+	-- station ID
+	DECLARE station_id INT;
+	
+	-- cursor to loop through all station IDs
+	DECLARE cur1 CURSOR FOR SELECT id FROM stations ORDER BY id;
+	
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+
+	IF (iv_station_id IS NULL) THEN
+
+		-- open cursor
+		OPEN cur1;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur1 INTO station_id;
+		    
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate monthly_met_data for a specific month for a specific station
+		    CALL generate_monthly_met_data(ii_year, ii_month, station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur1;
+		
+	ELSE
+
+		-- call stored procedure to calculate monthly_met_data for a specific month for a specific station
+		CALL generate_monthly_met_data(ii_year, ii_month, iv_station_id);
+	
+	END IF;
+	
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_monthly_met_data_by_month` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121323_revise_generate_monthly_met_data_by_month_range.php
+++ b/database/migrations/2022_07_06_121323_revise_generate_monthly_met_data_by_month_range.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateMonthlyMetDataByMonthRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_monthly_met_data_by_month_range`;
+
+CREATE PROCEDURE `generate_monthly_met_data_by_month_range`(IN ii_from_year INT, IN ii_from_month INT, IN ii_to_year INT, IN ii_to_month INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating monthly_met_data records for a month range for all met stations one by one
+*/
+
+	-- day difference between to_date and from_date
+	DECLARE diff INT;
+	
+	-- loop counter
+	DECLARE counter INT;
+	
+	-- date variable
+	DECLARE d_date DATE;
+	
+	-- year, month variable
+	DECLARE i_year INT;
+	DECLARE i_month INT;	
+	
+	-- first day of From year From month
+	DECLARE v_from_month_first_day DATE;
+	
+	-- prepare first day of From year From month
+	SET v_from_month_first_day = CONCAT(ii_from_year, '-', ii_from_month, '-01');
+
+	-- calculate month difference between To Year To Month and From Year From Month
+	SELECT PERIOD_DIFF( (ii_to_year * 100 + ii_to_month), (ii_from_year * 100 + ii_from_month) ) INTO diff;
+	
+	-- To Year and To Month must greater than or equal to From Year From Month
+	-- do nothing if To Year To Month is less than From Year From Month
+	IF (diff >= 0) THEN
+	
+		-- initialize counter
+		SET counter = 0;
+	
+		-- loop every month
+		for_loop: LOOP
+		
+			-- exit loop when all months handled
+			IF (counter > diff) THEN
+				LEAVE for_loop;
+			END IF;
+			
+			-- calculate a date for first day of a month
+			SELECT DATE_ADD(v_from_month_first_day, INTERVAL counter MONTH) INTO d_date;
+			
+			-- get year and month from the calculated date
+			SET i_year = DATE_FORMAT(d_date, '%Y');
+			SET i_month = DATE_FORMAT(d_date, '%m');
+
+			IF (iv_station_id IS NULL) THEN
+				-- generate monthly summary for all stations for a calculated date
+				CALL generate_monthly_met_data_by_month(i_year, i_month, NULL);
+			ELSE
+				-- generate monthly summary for a station for a calculated date
+				CALL generate_monthly_met_data_by_month(i_year, i_month, iv_station_id);			
+			END IF;
+			
+			-- increment counter
+			SET counter = counter + 1;
+		
+		END LOOP for_loop;
+	
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_monthly_met_data_by_month_range` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121327_revise_generate_tendays_met_data_by_month.php
+++ b/database/migrations/2022_07_06_121327_revise_generate_tendays_met_data_by_month.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateTendaysMetDataByMonth extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_month`;
+
+CREATE PROCEDURE `generate_tendays_met_data_by_month`(IN ii_year INT, IN ii_month INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating tendays_met_data record for a specific month and all parts for all stations one by one
+*/
+
+	-- variable to determine whether it is end of cursor
+	DECLARE done INT DEFAULT FALSE;
+	
+	-- station ID
+	DECLARE station_id INT;
+	
+	-- cursor to loop through all station IDs
+	DECLARE cur1 CURSOR FOR SELECT id FROM stations ORDER BY id;
+	
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+
+	IF (iv_station_id IS NULL) THEN
+	
+		-- open cursor
+		OPEN cur1;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur1 INTO station_id;
+		    
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+			-- call stored procedure to calculate tendays_met_data for a specific month and all parts for a specific station
+		    CALL generate_tendays_met_data(ii_year, ii_month, 1, station_id);
+			CALL generate_tendays_met_data(ii_year, ii_month, 2, station_id);
+			CALL generate_tendays_met_data(ii_year, ii_month, 3, station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur1;
+
+
+	ELSE
+
+	    -- call stored procedure to calculate tendays_met_data for a specific month and all parts for a specific station
+	    CALL generate_tendays_met_data(ii_year, ii_month, 1, iv_station_id);
+	    CALL generate_tendays_met_data(ii_year, ii_month, 2, iv_station_id);
+	    CALL generate_tendays_met_data(ii_year, ii_month, 3, iv_station_id);
+	    
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_month` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121331_revise_generate_tendays_met_data_by_part.php
+++ b/database/migrations/2022_07_06_121331_revise_generate_tendays_met_data_by_part.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateTendaysMetDataByPart extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_part`;
+
+CREATE PROCEDURE `generate_tendays_met_data_by_part`(IN ii_year INT, IN ii_month INT, IN ii_part INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating tendays_met_data record for a specific month and part for all stations one by one
+*/
+
+	-- variable to determine whether it is end of cursor
+	DECLARE done INT DEFAULT FALSE;
+	
+	-- station ID
+	DECLARE station_id INT;
+	
+	-- cursor to loop through all station IDs
+	DECLARE cur1 CURSOR FOR SELECT id FROM stations ORDER BY id;
+	
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+
+	IF (iv_station_id IS NULL) THEN
+
+		-- open cursor
+		OPEN cur1;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur1 INTO station_id;
+		    
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+			-- call stored procedure to calculate tendays_met_data for a specific month and part for a specific station
+			CALL generate_tendays_met_data(ii_year, ii_month, ii_part, station_id);
+	
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur1;
+	
+	ELSE
+	
+		-- call stored procedure to calculate tendays_met_data for a specific month and part for a specific station
+		CALL generate_tendays_met_data(ii_year, ii_month, ii_part, iv_station_id);
+
+	END IF;
+	
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_part` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121336_revise_generate_tendays_met_data_by_year_range.php
+++ b/database/migrations/2022_07_06_121336_revise_generate_tendays_met_data_by_year_range.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateTendaysMetDataByYearRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_year_range`;
+
+CREATE PROCEDURE `generate_tendays_met_data_by_year_range`(IN ii_from_year INT, IN ii_to_year INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating tendays_met_data records for a year range for all met stations one by one
+*/
+
+	-- year difference between To Year and From Year
+	DECLARE diff INT;
+	
+	-- loop counter
+	DECLARE counter INT;
+	
+	SET diff = ii_to_year - ii_from_year;
+	
+	-- To Year must greater than or equal to From Year
+	-- do nothing if To Year is less than From Year
+	IF (diff >= 0) THEN
+	
+		-- initialize counter
+		SET counter = 0;
+	
+		-- loop every year
+		for_loop: LOOP
+		
+			-- exit loop when all years handled
+			IF (counter > diff) THEN
+				LEAVE for_loop;
+			END IF;
+			
+			IF (iv_station_id IS NULL) THEN
+			
+				-- generate tendays met data records for all stations for all months of a year
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 1, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 2, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 3, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 4, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 5, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 6, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 7, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 8, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 9, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 10, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 11, NULL);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 12, NULL);
+				
+			ELSE
+
+				-- generate tendays met data records for a station for all months of a year
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 1, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 2, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 3, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 4, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 5, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 6, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 7, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 8, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 9, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 10, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 11, iv_station_id);
+				CALL generate_tendays_met_data_by_month(ii_from_year + counter, 12, iv_station_id);
+			
+			END IF;
+			
+			-- increment counter
+			SET counter = counter + 1;
+		
+		END LOOP for_loop;
+	
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_tendays_met_data_by_year_range` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121340_revise_generate_yearly_met_data_by_year.php
+++ b/database/migrations/2022_07_06_121340_revise_generate_yearly_met_data_by_year.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateYearlyMetDataByYear extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_yearly_met_data_by_year`;
+
+CREATE PROCEDURE `generate_yearly_met_data_by_year`(IN ii_year INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating yearly_met_data record for a specific year for all stations one by one
+*/
+
+	-- variable to determine whether it is end of cursor
+	DECLARE done INT DEFAULT FALSE;
+	
+	-- station ID
+	DECLARE station_id INT;
+	
+	-- cursor to loop through all station IDs
+	DECLARE cur1 CURSOR FOR SELECT id FROM stations ORDER BY id;
+	
+	-- handler declaration
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+
+	IF (iv_station_id IS NULL) THEN
+
+		-- open cursor
+		OPEN cur1;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur1 INTO station_id;
+		    
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate yearly_met_data for a specific year for a specific station
+		    CALL generate_yearly_met_data(ii_year, station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur1;
+
+	ELSE
+
+		-- call stored procedure to calculate yearly_met_data for a specific year for a specific station
+		CALL generate_yearly_met_data(ii_year, iv_station_id);
+	
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_yearly_met_data_by_year` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121345_revise_generate_yearly_met_data_by_year_range.php
+++ b/database/migrations/2022_07_06_121345_revise_generate_yearly_met_data_by_year_range.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseGenerateYearlyMetDataByYearRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_yearly_met_data_by_year_range`;
+
+CREATE PROCEDURE `generate_yearly_met_data_by_year_range`(IN ii_from_year INT, IN ii_to_year INT, IN iv_station_id INT)
+BEGIN
+
+/*
+	Stored procedure for generating yearly_met_data records for a year range for all met stations one by one
+*/
+
+	-- year difference between To Year and From Year
+	DECLARE diff INT;
+	
+	-- loop counter
+	DECLARE counter INT;
+	
+	SET diff = ii_to_year - ii_from_year;
+	
+	-- To Year must greater than or equal to From Year
+	-- do nothing if To Year is less than From Year
+	IF (diff >= 0) THEN
+	
+		-- initialize counter
+		SET counter = 0;
+	
+		-- loop every year
+		for_loop: LOOP
+		
+			-- exit loop when all years handled
+			IF (counter > diff) THEN
+				LEAVE for_loop;
+			END IF;
+			
+			IF (iv_station_id IS NULL) THEN
+				-- generate yearly met data records for all stations for a year
+				CALL generate_yearly_met_data_by_year(ii_from_year + counter, NULL);
+			ELSE
+				-- generate yearly met data records for a station for a year
+				CALL generate_yearly_met_data_by_year(ii_from_year + counter, iv_station_id);
+			END IF;
+			
+			-- increment counter
+			SET counter = counter + 1;
+		
+		END LOOP for_loop;
+	
+	END IF;
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_yearly_met_data_by_year_range` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_07_06_121351_revise_remove_unnecessary_staging_records.php
+++ b/database/migrations/2022_07_06_121351_revise_remove_unnecessary_staging_records.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ReviseRemoveUnnecessaryStagingRecords extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `remove_unnecessary_staging_records`;
+
+CREATE PROCEDURE `remove_unnecessary_staging_records`()
+BEGIN
+
+    /*
+        Stored procedure for removing accumulated unnecessary staging records in table met_data_preview
+    */
+
+    -- remove met_data_preview records created 14 days before
+    DELETE FROM met_data_preview
+    WHERE created_at < DATE_SUB(NOW(), INTERVAL 14 DAY);
+
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `remove_unnecessary_staging_records` ";
+
+        DB::unprepared($procedure);
+    }
+}


### PR DESCRIPTION
Performed testing with postive result in local env.

Now we can generate summary met data for all stations or a particular station.

Examples:

-- generate daily met data for all stations
call generate_daily_met_data_by_date_range('2006-09-27', '2006-09-28', NULL);

-- generate daily met data for station 1
call generate_daily_met_data_by_date_range('2006-09-27', '2006-09-28', 1);

==========

I have also revised another two stored procedures:
1. generate_all_summary_met_data(): to delete existing records from four summary met data tables before re-generating them
2. remove_unnecessary_staging_records(): remove met_data_preview older than 14 days instead of 3 days (give us more buffer time for checking and investigation)
