### PR TITLE
add check for fecha_hora index

### DIFF
--- a/database/migrations/2022_07_05_180102_remove_fecha_hora_index_from_met_data_preview_table.php
+++ b/database/migrations/2022_07_05_180102_remove_fecha_hora_index_from_met_data_preview_table.php
@@ -13,9 +13,20 @@ class RemoveFechaHoraIndexFromMetDataPreviewTable extends Migration
      */
     public function up()
     {
+        // from https://stackoverflow.com/questions/45882990/how-can-indexes-be-checked-if-they-exist-in-a-laravel-migration
+
         Schema::table('met_data_preview', function (Blueprint $table) {
-            $table->dropIndex('fecha_hora');
+
+            // check if the index exists
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('met_data_preview');
+
+            if (array_key_exists("fecha_hora", $indexesFound)) {
+                $table->dropIndex("fecha_hora");
+            }
         });
+
+
     }
 
     /**


### PR DESCRIPTION
This fixes the deployment error on the staging site:

```
Migrating: 2022_07_05_180102_remove_fecha_hora_index_from_met_data_preview_table

   Illuminate\Database\QueryException 

  SQLSTATE[42000]: Syntax error or access violation: 1091 Can't DROP 'fecha_hora'; check that column/key exists (SQL: alter table `met_data_preview` drop index `fecha_hora`)
```

The issue is that the fecha_hora index does not exist on the staging site - either the staging site *or* my local db must have gotten out of sync with the migrations at some point. This fix makes it so that the index is only removed if it actually exists, so it should work regardless of the current state of the database.