### PR TITLE
add initial notification of file upload:

### DIFF
--- a/resources/js/components/UploaderWeatherData.vue
+++ b/resources/js/components/UploaderWeatherData.vue
@@ -548,7 +548,7 @@ export default {
                 .then(() => {
                     new Noty({
                         type: "info",
-                        text: "The file has been uploaded and is being validated",
+                        text: "The file is being uploaded and validated. Once complete, the data will be imported into the database.",
                         timeout: false,
                     }).show();
                     // this.busy = false;

--- a/resources/js/components/UploaderWeatherData.vue
+++ b/resources/js/components/UploaderWeatherData.vue
@@ -546,7 +546,12 @@ export default {
 
                 })
                 .then(() => {
-                    this.busy = false;
+                    new Noty({
+                        type: "info",
+                        text: "The file has been uploaded and is being validated",
+                        timeout: false,
+                    }).show();
+                    // this.busy = false;
                 })
 
 
@@ -610,7 +615,7 @@ export default {
                     this.trackProgress()
                 })
                 .listen("MetDataImportCompleted", payload => {
-
+                    this.busy = false;
                     if(!payload.success) {
                         this.uploadActive = false;
                         this.success = null;


### PR DESCRIPTION
Optional extra:
- On the staging site, there is a pronounced gap between the file upload POST request returning and the server-side event that sends the "import started" notification. 
- This update adds a first notice to inform the user that the file has been uploaded. and keeps the 'busy' status of the UI throughout the upload process so the user does not have that gap of 5-10 seconds before the import starts.