### PR TITLE
ignore met_data_preview 'id' field when inserting  into met_data table

### DIFF
--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -196,7 +196,7 @@ class FileController extends Controller
 
 
         // remove upload_id from column list
-        $columns = $columns->filter(fn($value, $key) => $value !=="upload_id");
+        $columns = $columns->filter(fn($value, $key) => $value !=="upload_id" && $value !== "id");
 
         $newDataQuery = MetDataPreview::select($columns->toArray())->where('upload_id', $upload_id);
 


### PR DESCRIPTION
Fixes the issue where met_data_preview entries would be ignored during final import if they have the same `id` as an existing met_data record.

Tested locally with the following:

1. truncate both met_data_preview and met_data tables;
2. add a single entry to met_data, dated  today; for station 2. Check this has id = 1.
3. Do the import with any correctly formated davis file.
4. The met_data_preview records should include one with id = 1. 
5. Complete / confirm the import.

Before this fix, the result was that all met_data_preview entries *except* the entry with id = 1 was inserted. 

After this fix, the result  is that all met_data_preview entries are inserted, so the final `select count(id) from met_data` is 1 higher than `select count(id) from met_data_preview`

(used this file for testing, for reference):
[02.txt](https://github.com/stats4sd/red-de-redes/files/9071888/02.txt)
 