### PR TITLE
Davis Import - add expected return statement for queue stability

### DIFF
--- a/app/Imports/DavisFileImport.php
+++ b/app/Imports/DavisFileImport.php
@@ -113,7 +113,7 @@ class DavisFileImport implements ToModel, WithEvents, WithCustomCsvSettings, Wit
             $newRow['file_id'] = $this->file_id;
             $newRow['station_id'] = $this->stationId;
 
-            $metDataItem = MetDataPreview::create($newRow->toArray());
+            return new MetDataPreview($newRow->toArray());
         } catch (Throwable $exception) {
             dump($row);
             dump($this->keyMap);
@@ -154,13 +154,13 @@ class DavisFileImport implements ToModel, WithEvents, WithCustomCsvSettings, Wit
     public
     function batchSize(): int
     {
-        return 1000;
+        return 300;
     }
 
     public
     function chunkSize(): int
     {
-        return 1000;
+        return 300;
     }
 
     public function rules(): array


### PR DESCRIPTION
This should fix the following issues:
- occasionaly on the server, the queue seems to stall when receiving a lot of new records from a single file. I suspect this is because it was processing each record individually instead of chunking them correctly.
  - The model() method was using MetDataPreview::create() instead of returning a new model instance, which means it was running 1 db query per record. 

This fix allows the importer to properly batch process the database imports, which will speed up the process. 

A side effect of this is that the front-end no longer receives the exact row number count. It receives the updates in chunks. I have reduced the chunk size to 300 so the front-end will receive progress updates in chunks of 300. 

