### PR TITLE
Unit conversions

### DIFF
--- a/app/Imports/DavisFileImport.php
+++ b/app/Imports/DavisFileImport.php
@@ -7,7 +7,7 @@ use App\Models\Met\File;
 use App\Models\Met\MetData;
 use App\Models\Met\MetDataPreview;
 use App\Models\User;
-use App\Services\UnitConversions;
+use App\Services\UnitConversionService;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -44,7 +44,7 @@ class DavisFileImport implements ToModel, WithEvents, WithCustomCsvSettings, Wit
     private int $stationId;
     private string $upload_id;
     private mixed $file_id;
-    private UnitConversions $unitConvertor;
+    private UnitConversionService $unitConvertor;
     private Collection $neededConversions;
 
     use RemembersRowNumber;
@@ -71,7 +71,7 @@ class DavisFileImport implements ToModel, WithEvents, WithCustomCsvSettings, Wit
         $this->user = $user;
 
         $this->neededConversions = $neededConversions;
-        $this->unitConvertor = new UnitConversions();
+        $this->unitConvertor = new UnitConversionService();
 
 
     }

--- a/app/Jobs/StartMetDataImport.php
+++ b/app/Jobs/StartMetDataImport.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -24,7 +25,7 @@ class StartMetDataImport implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(public File $fileRecord, public string $fileWithMergedHeaders, public User $user)
+    public function __construct(public File $fileRecord, public string $fileWithMergedHeaders, public Collection $neededConversions, public User $user)
     {
         //
     }
@@ -39,7 +40,7 @@ class StartMetDataImport implements ShouldQueue
         // tell the user that the import process has started
         MetDataImportStarted::dispatch($this->fileRecord, $this->user);
 
-        Excel::queueImport(new DavisFileImport($this->fileRecord, $this->user), $this->fileWithMergedHeaders, 'public', \Maatwebsite\Excel\Excel::TSV)->chain([
+        Excel::queueImport(new DavisFileImport($this->fileRecord, $this->neededConversions, $this->user), $this->fileWithMergedHeaders, 'public', \Maatwebsite\Excel\Excel::TSV)->chain([
             new MetDataImportCompletedJob($this->fileRecord, $this->user)
         ]);
 }

--- a/app/Services/UnitConversionService.php
+++ b/app/Services/UnitConversionService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-class UnitConversions
+class UnitConversionService
 {
 
     public static function getTempColumns()

--- a/app/Services/UnitConversions.php
+++ b/app/Services/UnitConversions.php
@@ -11,7 +11,15 @@ class UnitConversions
             'temperatura_externa',
             'hi_temp',
             'low_temp',
-            'temperatura_interna'
+            'temperatura_interna',
+            'leaf_temp_1',
+            'leaf_temp_2',
+            'leaf_temp_3',
+            'leaf_temp_4',
+            'soil_temp_1',
+            'soil_temp_2',
+            'soil_temp_3',
+            'soil_temp_4',
         ]);
     }
 
@@ -34,7 +42,7 @@ class UnitConversions
     {
         return collect([
             'rain',
-            'lluvia_hora'
+            'lluvia_hora',
         ]);
     }
 

--- a/app/Services/UnitConversions.php
+++ b/app/Services/UnitConversions.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services;
+
+class UnitConversions
+{
+
+    public static function getTempColumns()
+    {
+        return collect([
+            'temperatura_externa',
+            'hi_temp',
+            'low_temp',
+            'temperatura_interna'
+        ]);
+    }
+
+    public static function getPressureColumns()
+    {
+        return collect([
+            'presion_relativa'
+        ]);
+    }
+
+    public static function getWindSpeedColumns()
+    {
+        return collect([
+            'velocidad_viento',
+            'hi_speed',
+        ]);
+    }
+
+    public static function getRainfallColumns()
+    {
+        return collect([
+            'rain',
+            'lluvia_hora'
+        ]);
+    }
+
+    /***** TEMPERATURE *****/
+    public static function farenheitToCelcius(int|float $input): int|float
+    {
+        return ($input - 32) * 5 / 9;
+    }
+
+    /***** PRESSURE *****/
+
+    public static function inhgToHpa(int|float $input): int|float
+    {
+        return $input * 33.86389;
+    }
+
+    public static function mmhgToHpa(int|float $input): int|float
+    {
+        return $input * 1.33322;
+    }
+
+    /***** WIND SPEED *****/
+
+    public static function kmhToMs(int|float $input): int|float
+    {
+        return $input * 0.277778;
+    }
+
+    public static function mphToMs(int|float $input): int|float
+    {
+        return $input * 0.44704;
+    }
+
+
+    /***** RAINFALL *****/
+
+    public static function inchToMm(int|float $input): int|float
+    {
+        return $input * 25.4;
+    }
+
+
+}


### PR DESCRIPTION
Adds a UnitConversionsService class to provide conversions for non-standard units to the S.I units:

Temperature:
- farenheitToCelcius

Pressure:
- inhgToHpa
- mmhgToHpa

Wind Speed:
- kmhToMs
- mphToMs

Rainfall 
- inchToMm


The service also has helper functions that list the columns that require converting. The DavisImporter receives the list of conversions needed from the request, and then calls the helper service where needed to calculate the correct values. 

The lists of columns are not 100% complete (they will need updating the Chinas stations), but they address all the columns that UMSA are currently interested in for the Davis station data. 

The idea is that all the conversion functions can be kept together in the service class, so we can easily reference it in 
different places and also update the conversion functions and/or the lists of columns when needed. 


