### PR TITLE
Long term solution

### DIFF
--- a/database/migrations/2022_05_16_135142_find_month_part.php
+++ b/database/migrations/2022_05_16_135142_find_month_part.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FindMonthPart extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $function =         
+"
+CREATE FUNCTION `find_month_part`(
+	in_date	VARCHAR(10)
+
+) RETURNS int
+    DETERMINISTIC
+BEGIN
+
+    /*
+        Function for finding the month part of a date
+         - Month part: 1 (for day 1 to day 10)
+         - Month part: 2 (for day 11 to day 20)
+         - Month part: 3 (for day 21 to day 31)
+    */
+
+	DECLARE in_day INT;
+	
+	DECLARE month_part INT;
+	
+	SET in_day = day(in_date);
+	
+	IF in_day >= 1 AND in_day <= 10 THEN
+		RETURN 1;
+		SET month_part = 1;
+	ELSEIF in_day >= 11 AND in_day <= 20 THEN
+		SET month_part = 2;
+	ELSEIF in_day >= 21 AND in_day <= 31 THEN
+		SET month_part = 3;
+	END IF;
+	
+	RETURN month_part;
+
+END
+";
+
+        DB::unprepared($function);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $function = "DROP FUNCTION IF EXISTS `find_month_part` ";
+
+        DB::unprepared($function);
+    }
+}

--- a/database/migrations/2022_05_16_135953_create_wk_summary_met_data_table.php
+++ b/database/migrations/2022_05_16_135953_create_wk_summary_met_data_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWkSummaryMetDataTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('wk_summary_met_data', function (Blueprint $table) {
+            $table->id();
+
+            // date and station id, requried fields
+            $table->date('fecha');
+            $table->integer('station_id')->default('0');
+
+            $table->integer('year');
+            $table->integer('month');
+            $table->integer('part');
+
+            $table->integer('latest_actual_no_of_records');
+            $table->integer('previous_actual_no_of_records')->nullable();
+            $table->integer('difference');
+
+            $table->timestamp('previous_created_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('wk_summary_met_data');
+    }
+}

--- a/database/migrations/2022_05_17_094643_generate_delta_summary_met_data.php
+++ b/database/migrations/2022_05_17_094643_generate_delta_summary_met_data.php
@@ -1,0 +1,266 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class GenerateDeltaSummaryMetData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure =         
+"
+DROP PROCEDURE IF EXISTS `generate_delta_summary_met_data`;
+
+CREATE PROCEDURE `generate_delta_summary_met_data`()
+BEGIN
+
+/*
+	Stored procedure for generating delta summary met data (daily, tendays, monthly, yearly) from newly uploaded raw met data
+	P.S. use multiple BEGIN END blocks to separate different part of business logic
+	
+	Program flow:
+	1. Generate working table records to find out which date has newly uploaded raw met data
+	2. Re-generate delta daily_met_data
+	3. Re-generate delta tendays_met_data
+	4. Re-generate delta monthly_met_data
+	5. Re-generate delta yearly_met_data
+	6. Print debug message	
+*/
+
+	-- 1. Generate working table records to find out which date has newly uploaded raw met data
+	BEGIN
+		-- remove all existing records in working table
+		DELETE FROM wk_summary_met_data;
+	
+		-- Below are all possible cases:
+		-- 1. More number of records: There were existing raw met data before, and there are some new raw met data now. Re-generate summary met data records
+		-- 2. From non existed to existed: There was no raw met data before, and there are some new met data now. Re-generate summary met data records
+		-- 3. Less number of records: Suppose it should not happen as there is no mechanism to remove the uploaded raw met data in database. Re-generate summary met data records
+	    -- 4. From existed to non existed: Suppose it should not happen, there were raw met data before, and there is no met data now. This case is not detected	    
+	    -- 5. Equial number of records: That means no new raw met data uploaded. No action is required
+	    --
+	    -- Conclusion:
+	    -- 1. Suppose we should re-generate summary met data records for dates with difference > 0 only (new records found)
+	    -- 2. To play safe, also re-generate summary met data records for date with difference < 0 (some records removed),
+	    --    although it should not happen. Just in case raw met data records removed due to some reasons
+	    -- 3. There will be no record in working table if all raw met data removed for a particular date and station.
+	    --    In this case, the previously generated daily_met_data records will still be used for generating tendays, monthly, yearly met data.
+	    --    Note that this case is not detected, and this case should not happen.
+	    -- 4. No need to do anything for records with difference = 0 (no change on raw met data records)
+	    --
+		
+		INSERT INTO wk_summary_met_data (fecha, station_id, year, month, part, latest_actual_no_of_records, previous_actual_no_of_records, difference, previous_created_at, created_at, updated_at)
+		SELECT tb.fecha, tb.station_id, YEAR(tb.fecha) AS year, MONTH(tb.fecha) AS month, find_month_part(tb.fecha) AS part, 
+		COUNT(*) AS latest_actual_no_of_records, tb.actual_no_of_records AS previous_actual_no_of_records, 
+		COUNT(*) - IFNULL(tb.actual_no_of_records, 0) AS difference,
+		tb.created_at AS previous_created_at, NOW(), NOW()
+		FROM met_data ta 
+		LEFT JOIN daily_met_data tb 
+		ON DATE(ta.fecha_hora) = tb.fecha
+		AND ta.station_id = tb.station_id
+		GROUP BY tb.fecha, tb.station_id;
+
+	END;
+
+
+
+	-- 2. Re-generate delta daily_met_data
+	BEGIN
+		-- variable to determine whether it is end of cursor
+		DECLARE done INT DEFAULT FALSE;
+		
+		-- variables for retrieving values from cursors
+		-- P.S. local variable names and table column name must not be the same
+		DECLARE v_fecha VARCHAR(10);
+		DECLARE i_station_id INT;
+
+		-- cursor to loop through all fecha and station with difference
+		DECLARE cur CURSOR FOR SELECT fecha, station_id FROM wk_summary_met_data WHERE difference <> 0;
+		
+		-- handler declaration
+		DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+		-- open cursor
+		OPEN cur;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur INTO v_fecha, i_station_id;
+			
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate daily_met_data for a specific date for a specific station
+		    CALL generate_daily_met_data(v_fecha, i_station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur;
+	END;
+	
+	
+	
+	-- 3. Re-generate delta tendays_met_data
+	BEGIN
+		-- variable to determine whether it is end of cursor
+		DECLARE done INT DEFAULT FALSE;
+		
+		-- variables for retrieving values from cursors
+		-- P.S. local variable names and table column name must not be the same
+		DECLARE i_year INT;
+		DECLARE i_month INT;
+		DECLARE i_part INT;
+		DECLARE i_station_id INT;
+
+		-- cursor to loop through all year, month, part and station with difference
+		DECLARE cur CURSOR FOR SELECT year, month, part, station_id FROM wk_summary_met_data WHERE difference <> 0 GROUP BY year, month, part, station_id;
+		
+		-- handler declaration
+		DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+		-- open cursor
+		OPEN cur;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur INTO i_year, i_month, i_part, i_station_id;
+			
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate tendays_met_data for a specific year, month, part for a specific station
+		    CALL generate_tendays_met_data(i_year, i_month, i_part, i_station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur;
+	END;
+	
+
+
+	-- 4. Re-generate delta monthly_met_data
+	BEGIN
+		-- variable to determine whether it is end of cursor
+		DECLARE done INT DEFAULT FALSE;
+		
+		-- variables for retrieving values from cursors
+		-- P.S. local variable names and table column name must not be the same
+		DECLARE i_year INT;
+		DECLARE i_month INT;
+		DECLARE i_station_id INT;
+	
+		-- cursor to loop through all year, month and station with difference
+		DECLARE cur CURSOR FOR SELECT year, month, station_id FROM wk_summary_met_data WHERE difference <> 0 GROUP BY year, month, station_id;
+		
+		-- handler declaration
+		DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+		-- open cursor
+		OPEN cur;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur INTO i_year, i_month, i_station_id;
+			
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate monthly_met_data for a specific year, month for a specific station
+		    CALL generate_monthly_met_data(i_year, i_month, i_station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur;
+	END;
+
+
+
+	-- 5. Re-generate delta yearly_met_data
+	BEGIN
+		-- variable to determine whether it is end of cursor
+		DECLARE done INT DEFAULT FALSE;
+		
+		-- variables for retrieving values from cursors
+		-- P.S. local variable names and table column name must not be the same
+		DECLARE i_year INT;
+		DECLARE i_station_id INT;
+	
+		-- cursor to loop through all year and station with difference
+		DECLARE cur CURSOR FOR SELECT year, station_id FROM wk_summary_met_data WHERE difference <> 0 GROUP BY year, station_id;
+		
+		-- handler declaration
+		DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+		-- open cursor
+		OPEN cur;
+		
+		-- loop
+	  	read_loop: LOOP
+	  	
+	  		-- fetch one record from cursor
+			FETCH cur INTO i_year, i_station_id;
+			
+		    -- exit loop if it is end of cursor
+		    IF done THEN
+		    	LEAVE read_loop;
+		    END IF;
+		    
+		    -- call stored procedure to calculate yearly_met_data for a specific year for a specific station
+		    CALL generate_yearly_met_data(i_year, i_station_id);
+	    
+	    -- end loop
+	  	END LOOP read_loop;
+		
+		-- close cursor
+		CLOSE cur;
+	END;
+	
+
+	-- 6. Print debug message
+	SELECT 'Completed' from dual;
+	
+END
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP PROCEDURE IF EXISTS `generate_delta_summary_met_data` ";
+
+        DB::unprepared($procedure);
+    }
+}

--- a/database/migrations/2022_05_17_094938_create_schedule_job_to_generate_delta_summary_met_data.php
+++ b/database/migrations/2022_05_17_094938_create_schedule_job_to_generate_delta_summary_met_data.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateScheduleJobToGenerateDeltaSummaryMetData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // For correct indentation in MySQL stored procedure to be created,
+        // MySQL program source code needs to be stored in below format
+
+        $procedure = 
+"
+CREATE EVENT event_recurring_generate_delta_summary_met_data
+ON SCHEDULE EVERY 10 MINUTE
+STARTS '2021-11-01 00:00:00'
+DO
+BEGIN
+	CALL generate_delta_summary_met_data();
+END;
+";
+
+        DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $procedure = "DROP EVENT IF EXISTS event_recurring_generate_delta_summary_met_data; ";
+
+        DB::unprepared($procedure);
+    }
+}


### PR DESCRIPTION
This long term solution is submitted as a PR for reference only.
It is submitted for keeping program source code files in GitHub, and make a record for possible future reference.
Suppose we DO NOT need to merge any program source code in this PR to branch dev.

This long term solution was developed just after the short term workaround developed, which re-generates all summary met data including daily, tendays, monthly, yearly at midnight every day.

Re-generating all summary met data takes a long time, and it will take longer time when we have more and more met_data records.
We need a long term solution to find out the met_data delta change and re-generate summary met data for the delta change only.

The stored procedure generate_delta_summary_met_data() works fine when I create it in TablePlus, but it has error when I create it by migration file.
This has not been resolved as there are other tasks with higher priority in mid May 2022.

As the PHP file upload is implemented in early July 2022, summary met data will be generated just after file upload. (currently just daily met data, will include tendays, monthly, yearly met data soon) 
It is no longer necessary to have either short term workaround or long term solution.

Here I will describe the idea of the long term solution, which is focus on finding out the delta change of met_data records for summary met data re-generation.

Example:

Day 1
We have generated all summary met data.
In daily_met_data, we have a column called actual_no_of_records, which contains the total number of met_data records for a particular date and station.
e.g. 2022-01-01, station 11, there are 15 met_data records.

![image](https://user-images.githubusercontent.com/86968034/178512296-8a53a1ec-48a3-45c3-9050-8b7642a14313.png)


Day 2
User uploaded a met data file for station 11, which contains 10 records for 2022-01-01.
The related daily_met_data record for 2022-01-01, station 11 still have 15 in column actual_no_of_records.
This is correct, because daily_met_data record has not been re-generated.

The idea is to create a working table, run a query to generate a working summary according to latest met_data records.
And then compare previously generated met_data.actual_no_of_records and the latest total number of met_data for a particular date and station.
Once there is difference found, that means there are new records imported into database after daily_met_data record generated.
We need to re-generate daily, tendays, monthly, yearly summary met data for this date and station.

E.g. In the working table, 2022-01-01, station 11, latest_actual_no_of_records will be 25, difference will be 10.  (highlighted in GREEN)
P.S. The number showing in this screen shot does not match with this example. The screen shot is just for illustrating the idea.

![image](https://user-images.githubusercontent.com/86968034/178512579-a859ed64-598d-4be6-9b20-798f75b7b0c8.png)



By looping through all records in this working summary table, and re-generate summary met data when delta change found.
Summary met data records will be only re-generated for the delta change.
The processing time required is much shorter than re-generated all summary met data.

Here are something to aware about this approach:

Below are all possible cases:
1. More number of records: There were existing raw met data before, and there are some new raw met data now. Re-generate summary met data records
2. From non existed to existed: There was no raw met data before, and there are some new met data now. Re-generate summary met data records
3. Less number of records: Suppose it should not happen as there is no mechanism to remove the uploaded raw met data in database. Re-generate summary met data records
4. From existed to non existed: Suppose it should not happen, there were raw met data before, and there is no met data now. This case is not detected	    
5. Equial number of records: That means no new raw met data uploaded. No action is required

Conclusion:
1. Suppose we should re-generate summary met data records for dates with difference > 0 only (new records found)
2. To play safe, also re-generate summary met data records for date with difference < 0 (some records removed),
   although it should not happen. Just in case raw met data records removed due to some reasons
3. There will be no record in working table if all raw met data removed for a particular date and station.
   In this case, the previously generated daily_met_data records will still be used for generating tendays, monthly, yearly met data.
   Note that this case is not detected, and this case should not happen.
4. No need to do anything for records with difference = 0 (no change on raw met data records)