### PR TITLE
Fix heatmap chart

### DIFF
--- a/app/Console/Commands/MetDataPreviewHousekeeping.php
+++ b/app/Console/Commands/MetDataPreviewHousekeeping.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Console\Command;
+
+class MetDataPreviewHousekeeping extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'metdatapreview_housekeeping';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Perform housekeeping for met_data_preview table, remove met_data_preview records older than 14 days';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // remove met_data_preview records older than 14 days
+        DB::table('met_data_preview')->where('created_at', '<=', Carbon::now()->subDays(14)->toDateTimeString())->delete();
+
+        return 'success';
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,6 +30,9 @@ class Kernel extends ConsoleKernel
             $schedule->job(new UpdateFormCsvFiles($xlsform))
             ->daily();
         }
+
+        // daily schedule job to remove met_data_preview records older than 14 days
+        $schedule->command('metdatapreview_housekeeping')->dailyAt('08:19');
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,7 +32,7 @@ class Kernel extends ConsoleKernel
         }
 
         // daily schedule job to remove met_data_preview records older than 14 days
-        $schedule->command('metdatapreview_housekeeping')->dailyAt('08:19');
+        $schedule->command('metdatapreview_housekeeping')->dailyAt('00:01');
     }
 
     /**

--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -173,9 +173,8 @@ class FileController extends Controller
     public function cancelUpload($upload_id)
     {
 
-        if ($upload_id) {
-            DB::table('met_data_preview')->where('upload_id', '=', $upload_id)->delete();
-        }
+        // For traceability and consistency, do not remove met_data_preview records no matter user click "Cancel" or "Confirm" button
+        // For housekeeping and performance concern, met_data_preview records older than 14 days will be removed by daily schedule job
 
         Alert::add('info', 'Carga cancelada: todos los datos de la vista previa se han eliminado de la base de datos')->flash();
 

--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -221,11 +221,31 @@ class FileController extends Controller
         $maxDate = (new Carbon($maxDate))->toDateString();
         $minDate = (new Carbon($minDate))->toDateString();
 
-        $result = \DB::select(
+        $maxMonth = substr($maxDate, 5, 2);
+        $minMonth = substr($minDate, 5, 2);
+
+        $maxYear = substr($maxDate, 0, 4);
+        $minYear = substr($minDate, 0, 4);
+
+        $dailyResult = \DB::select(
             "call generate_daily_met_data_by_date_range(?, ?, ?);",
             [$minDate, $maxDate, $fileRecord->station_id]
         );
 
+        $tendaysResult = \DB::select(
+            "call generate_tendays_met_data_by_year_range(?, ?, ?);",
+            [$minYear, $maxYear, $fileRecord->station_id]
+        );
+
+        $monthlyResult = \DB::select(
+            "call generate_monthly_met_data_by_month_range(?, ?, ?, ?, ?);",
+            [$minYear, $minMonth, $maxYear, $maxMonth, $fileRecord->station_id]
+        );
+
+        $yearlyResult = \DB::select(
+            "call generate_yearly_met_data_by_year_range(?, ?, ?);",
+            [$minYear, $maxYear, $fileRecord->station_id]
+        );
 
         Alert::add('success', "Carga completa. Todos los registros {$metDataCount} se almacenan en la base de datos y se han calculado los resúmenes diarios.")->flash();
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -5,7 +5,7 @@ namespace App\Http;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
-{
+{ 
     /**
      * The application's global HTTP middleware stack.
      *

--- a/app/Jobs/MetDataImportCompletedJob.php
+++ b/app/Jobs/MetDataImportCompletedJob.php
@@ -71,10 +71,15 @@ class MetDataImportCompletedJob implements ShouldQueue
         // number of not existed records = number of uploaded records - number of existed records
         $numberNotExistedRecords = $metDataPreviewCount - $numberExistedRecords;
 
+        $minFechaHora = MetDataPreview::where('upload_id', $this->fileRecord->upload_id)->min('fecha_hora');
+        $maxFechaHora = MetDataPreview::where('upload_id', $this->fileRecord->upload_id)->max('fecha_hora');
+        
         // update file record
         $this->fileRecord->update([
             'new_records_count' => $numberNotExistedRecords,
             'duplicate_records_count' => $numberExistedRecords,
+            'min_fecha_hora' => $minFechaHora,
+            'max_fecha_hora' => $maxFechaHora,
         ]);
 
         $maxTemp = MetDataPreview::where('upload_id', $this->fileRecord->upload_id)->max('hi_temp');
@@ -102,6 +107,8 @@ class MetDataImportCompletedJob implements ShouldQueue
                 'number_uploaded_records' => $metDataPreviewCount,
                 'number_existed_records' => $numberExistedRecords,
                 'number_not_existed_records' => $numberNotExistedRecords,
+                'min_fecha_hora' => $minFechaHora,
+                'max_fecha_hora' => $maxFechaHora,
                 'scenario' => $scenario,
                 'adviceMessage' => $adviceMessage,
                 'error_data' => null,

--- a/database/migrations/2022_07_22_091637_add_two_columns_to_files_table.php
+++ b/database/migrations/2022_07_22_091637_add_two_columns_to_files_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTwoColumnsToFilesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->timestamp('min_fecha_hora')->after('duplicate_records_count')->nullable();
+            $table->timestamp('max_fecha_hora')->after('min_fecha_hora')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropColumn('min_fecha_hora');
+            $table->dropColumn('max_fecha_hora');
+        });
+    }
+}

--- a/resources/js/components/UploaderWeatherData.vue
+++ b/resources/js/components/UploaderWeatherData.vue
@@ -151,6 +151,8 @@
                                 <div class="alert alert-secondary" v-if="previewData!=null">
                                     <ul>
                                         <li>Hay {{ total_rows }} filas</li>
+                                        <li>Fecha hora mínima de los registros:<b> {{ min_fecha_hora }} </b></li>
+                                        <li>Fecha hora máxima de los registros:<b> {{ max_fecha_hora }} </b></li>
                                         <li>Temperatura mínima de los registros:<b> {{ min_temp }} ºC</b></li>
                                         <li>Temperatura máxima de los registros:<b> {{ max_temp }} ºC</b></li>
                                         <li>Precipitación máxima diaria de registros:<b> {{ max_daily_rain }} mm</b></li>
@@ -328,6 +330,8 @@ export default {
     data() {
         this.trackProgress = _.debounce(this.trackProgress, 1000);
         return {
+            min_fecha_hora: null,
+            max_fecha_hora: null,
             max_temp: null,
             min_temp: null,
             max_daily_rain: null,
@@ -633,6 +637,8 @@ export default {
                     this.total_rows = payload.data.met_data_preview.total;
                     this.previewData = payload.data.met_data_preview.data;
                     this.upload_id = (this.previewData[0]['upload_id']);
+                    this.min_fecha_hora = payload.data.min_fecha_hora;
+                    this.max_fecha_hora = payload.data.max_fecha_hora;
                     this.min_temp = payload.data.min_temp;
                     this.max_temp = payload.data.max_temp;
                     this.max_daily_rain = payload.data.max_daily_rain;

--- a/scripts/R/graph_heatmap.R
+++ b/scripts/R/graph_heatmap.R
@@ -10,8 +10,11 @@ selected_start_year <- args[3]
 selected_end_year <- ifelse(selected_aggregation=="senamhi_daily", selected_start_year, args[4])
 selected_variable <- args[5]
 
+# Chart shows month "01" of next year when end date on or after 15 Dec of this year.
+# Tried to set end date as 31 December of this year, data between 31 December 00:00:00 and 23:59:59 are not included.
+# In order to show data on 31 December, we need to set end data as 1 Jan of next year.
 date_start <- as.Date(paste0(selected_start_year,"-1-1"))
-date_end <- as.Date(paste0(selected_end_year,"-12-1"))
+date_end <- as.Date(paste0(strtoi(selected_end_year) + 1,"-1-1"))
 
 dotenv::load_dot_env("../../.env")
 

--- a/scripts/R/graph_heatmap.R
+++ b/scripts/R/graph_heatmap.R
@@ -9,12 +9,8 @@ selected_station <- as.vector(strsplit(selected_station, ",")[[1]])
 selected_start_year <- args[3]
 selected_end_year <- ifelse(selected_aggregation=="senamhi_daily", selected_start_year, args[4])
 selected_variable <- args[5]
-
-# Chart shows month "01" of next year when end date on or after 15 Dec of this year.
-# Tried to set end date as 31 December of this year, data between 31 December 00:00:00 and 23:59:59 are not included.
-# In order to show data on 31 December, we need to set end data as 1 Jan of next year.
 date_start <- as.Date(paste0(selected_start_year,"-1-1"))
-date_end <- as.Date(paste0(strtoi(selected_end_year) + 1,"-1-1"))
+date_end <- as.Date(paste0(selected_end_year),"-12-1"))
 
 dotenv::load_dot_env("../../.env")
 

--- a/scripts/R/graph_heatmap.R
+++ b/scripts/R/graph_heatmap.R
@@ -9,8 +9,13 @@ selected_station <- as.vector(strsplit(selected_station, ",")[[1]])
 selected_start_year <- args[3]
 selected_end_year <- ifelse(selected_aggregation=="senamhi_daily", selected_start_year, args[4])
 selected_variable <- args[5]
+
+# Chart shows month "01" of next year when end date on or after 15 Dec of this year.
+# Tried to set end date as 31 December of this year, data between 31 December 00:00:00 and 23:59:59 are not included.
+# In order to show data on 31 December, we need to set end data as 1 Jan of next year.
 date_start <- as.Date(paste0(selected_start_year,"-1-1"))
-date_end <- as.Date(paste0(selected_end_year),"-12-1"))
+date_end <- as.Date(paste0(strtoi(selected_end_year) + 1,"-1-1"))
+
 
 dotenv::load_dot_env("../../.env")
 


### PR DESCRIPTION
Regarding the change of heatmap chart:

Findings:
1. It seems that end date is set to 1 December of end year. All data in December are excluded.
`date_end <- as.Date(paste0(selected_end_year,"-12-1"))`

2. as.Date create a date object without timestamp. If we create end date object as "2022-12-31". Data between 2022-12-31 00:00:00 to 2022-12-31 23:59:59 are excluded. The simplest way to include them is to set end date as "2023-01-01", which is the first day of next year.

3. Chart starts to show January of next year as "01" since end date "2022-12-15".

```
End Date        Months Showed
==============================
2022-12-01	01 to 12
2022-12-14	01 to 12
2022-12-15	01 to 01
2023-01-01	01 to 01
```

BEFORE FIX:
2022-12-31 data not showed on heatmap chart
![image](https://user-images.githubusercontent.com/86968034/180457591-36141467-c252-49a4-adc1-dc914170987c.png)

AFTER FIX:
2022-12-31 data showed on heatmap chart
![image](https://user-images.githubusercontent.com/86968034/180457604-57bb8263-0fb7-468e-8a2c-7c003fbb2d12.png)