### PR TITLE
Fix heatmap chart

### DIFF
--- a/scripts/R/graph_heatmap.R
+++ b/scripts/R/graph_heatmap.R
@@ -9,8 +9,13 @@ selected_station <- as.vector(strsplit(selected_station, ",")[[1]])
 selected_start_year <- args[3]
 selected_end_year <- ifelse(selected_aggregation=="senamhi_daily", selected_start_year, args[4])
 selected_variable <- args[5]
+
+# Chart shows month "01" of next year when end date on or after 15 Dec of this year.
+# Tried to set end date as 31 December of this year, data between 31 December 00:00:00 and 23:59:59 are not included.
+# In order to show data on 31 December, we need to set end data as 1 Jan of next year.
 date_start <- as.Date(paste0(selected_start_year,"-1-1"))
-date_end <- as.Date(paste0(selected_end_year),"-12-1"))
+date_end <- as.Date(paste0(strtoi(selected_end_year) + 1,"-1-1"))
+
 
 dotenv::load_dot_env("../../.env")
 


### PR DESCRIPTION
Regarding the change of heatmap chart:

Findings:
1. It seems that end date is set to 1 December of end year. All data in December are excluded.
`date_end <- as.Date(paste0(selected_end_year,"-12-1"))`

2. as.Date create a date object without timestamp. If we create end date object as "2022-12-31". Data between 2022-12-31 00:00:00 to 2022-12-31 23:59:59 are excluded. The simplest way to include them is to set end date as "2023-01-01", which is the first day of next year.

3. Chart starts to show January of next year as "01" since end date "2022-12-15".

```
End Date        Months Showed
==============================
2022-12-01	01 to 12
2022-12-14	01 to 12
2022-12-15	01 to 01
2023-01-01	01 to 01
```

BEFORE FIX:
2022-12-31 data not showed on heatmap chart
![image](https://user-images.githubusercontent.com/86968034/180458270-dcbd35b2-4102-4381-8717-fb08c6479210.png)


AFTER FIX:
2022-12-31 data showed on heatmap chart
![image](https://user-images.githubusercontent.com/86968034/180458284-c4d24c0b-2be6-4f9d-bafd-ffdc0541b148.png)
